### PR TITLE
Catch overflow before it causes a segfault.

### DIFF
--- a/src/svm.cpp
+++ b/src/svm.cpp
@@ -880,6 +880,9 @@ int Solver::select_working_set(int &out_i, int &out_j)
 		}
 	}
 
+	if (Gmax_idx < 0 || Gmin_idx < 0)
+		error("Overflow / NaNs produced.");
+
 	if(Gmax+Gmax2 < eps)
 		return 1;
 
@@ -1132,6 +1135,8 @@ int Solver_NU::select_working_set(int &out_i, int &out_j)
 		}
 	}
 
+	if (Gmin_idx == -1 || ((y[Gmin_idx] == +1)?Gmaxp_idx:Gmaxn_idx) == -1)
+		error("Overflow / NaNs produced.");
 	if(max(Gmaxp+Gmaxp2,Gmaxn+Gmaxn2) < eps)
 		return 1;
 


### PR DESCRIPTION
Fixes the following segfault (at least on linux x86_64):

```R
# Warning, this crashes the R session
library("e1071")
svm(x=matrix(c(20, rep(13:15, 37)), ncol=4), y=rep(1:2, each=14),
    kernel="polynomial", degree=10, gamma=9.39, scale=FALSE)
```